### PR TITLE
chore(deps): Update paperspace-go org capitalization.

### DIFF
--- a/cluster-autoscaler/cloudprovider/paperspace/paperspace_manager.go
+++ b/cluster-autoscaler/cloudprovider/paperspace/paperspace_manager.go
@@ -28,7 +28,7 @@ import (
 	"strconv"
 	"strings"
 
-	psgo "github.com/paperspace/paperspace-go"
+	psgo "github.com/Paperspace/paperspace-go"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/cluster-autoscaler/cloudprovider/paperspace/paperspace_node_group.go
+++ b/cluster-autoscaler/cloudprovider/paperspace/paperspace_node_group.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 
-	psgo "github.com/paperspace/paperspace-go"
+	psgo "github.com/Paperspace/paperspace-go"
 	apiv1 "k8s.io/api/core/v1"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 

--- a/cluster-autoscaler/cloudprovider/paperspace/paperspace_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/paperspace/paperspace_node_group_test.go
@@ -24,7 +24,7 @@ package paperspace
 //	"testing"
 //
 //	"github.com/digitalocean/godo"
-//	psgo "github.com/paperspace/paperspace-go"
+//	psgo "github.com/Paperspace/paperspace-go"
 //	"github.com/stretchr/testify/assert"
 //	"github.com/stretchr/testify/mock"
 //	apiv1 "k8s.io/api/core/v1"

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -10,11 +10,11 @@ require (
 	cloud.google.com/go v0.34.0
 	github.com/Azure/azure-sdk-for-go v21.4.0+incompatible
 	github.com/Azure/go-autorest v11.1.2+incompatible
+	github.com/Paperspace/paperspace-go v0.3.0
 	github.com/aws/aws-sdk-go v1.28.14
 	github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 	github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be
-	github.com/paperspace/paperspace-go v0.2.0
 	github.com/prometheus/client_golang v0.9.2
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/pflag v1.0.1
@@ -268,35 +268,35 @@ replace (
 	gopkg.in/yaml.v1 => gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
 	gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
 	gotest.tools => gotest.tools v2.2.0+incompatible
-	k8s.io/api => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/api
-	k8s.io/apiextensions-apiserver => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/apiextensions-apiserver
-	k8s.io/apimachinery => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/apimachinery
-	k8s.io/apiserver => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/apiserver
-	k8s.io/cli-runtime => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/cli-runtime
-	k8s.io/client-go => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/client-go
-	k8s.io/cloud-provider => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/cloud-provider
-	k8s.io/cluster-bootstrap => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/cluster-bootstrap
-	k8s.io/code-generator => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/code-generator
-	k8s.io/component-base => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/component-base
-	k8s.io/cri-api => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/cri-api
-	k8s.io/csi-translation-lib => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/csi-translation-lib
+	k8s.io/api => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/api
+	k8s.io/apiextensions-apiserver => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/apiextensions-apiserver
+	k8s.io/apimachinery => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/apimachinery
+	k8s.io/apiserver => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/apiserver
+	k8s.io/cli-runtime => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/cli-runtime
+	k8s.io/client-go => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/client-go
+	k8s.io/cloud-provider => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/cloud-provider
+	k8s.io/cluster-bootstrap => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/cluster-bootstrap
+	k8s.io/code-generator => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/code-generator
+	k8s.io/component-base => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/component-base
+	k8s.io/cri-api => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/cri-api
+	k8s.io/csi-translation-lib => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/csi-translation-lib
 	k8s.io/gengo => k8s.io/gengo v0.0.0-20190116091435-f8a0810f38af
 	k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog => k8s.io/klog v0.3.1
-	k8s.io/kube-aggregator => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/kube-aggregator
-	k8s.io/kube-controller-manager => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/kube-controller-manager
+	k8s.io/kube-aggregator => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/kube-aggregator
+	k8s.io/kube-controller-manager => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/kube-controller-manager
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30
-	k8s.io/kube-proxy => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/kube-proxy
-	k8s.io/kube-scheduler => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/kube-scheduler
-	k8s.io/kubectl => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/kubectl
-	k8s.io/kubelet => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/kubelet
-	k8s.io/legacy-cloud-providers => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/legacy-cloud-providers
-	k8s.io/metrics => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/metrics
-	k8s.io/node-api => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/node-api
+	k8s.io/kube-proxy => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/kube-proxy
+	k8s.io/kube-scheduler => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/kube-scheduler
+	k8s.io/kubectl => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/kubectl
+	k8s.io/kubelet => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/kubelet
+	k8s.io/legacy-cloud-providers => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/legacy-cloud-providers
+	k8s.io/metrics => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/metrics
+	k8s.io/node-api => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/node-api
 	k8s.io/repo-infra => k8s.io/repo-infra v0.0.0-20181204233714-00fe14e3d1a3
-	k8s.io/sample-apiserver => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/sample-apiserver
-	k8s.io/sample-cli-plugin => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/sample-cli-plugin
-	k8s.io/sample-controller => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/sample-controller
+	k8s.io/sample-apiserver => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/sample-apiserver
+	k8s.io/sample-cli-plugin => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/sample-cli-plugin
+	k8s.io/sample-controller => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/sample-controller
 	k8s.io/utils => k8s.io/utils v0.0.0-20190221042446-c2654d5206da
 	modernc.org/cc => modernc.org/cc v1.0.0
 	modernc.org/golex => modernc.org/golex v1.0.0
@@ -311,6 +311,6 @@ replace (
 
 replace github.com/rancher/go-rancher => github.com/rancher/go-rancher v0.1.0
 
-replace github.com/paperspace/paperspace-go => github.com/paperspace/paperspace-go v0.2.0
+replace github.com/Paperspace/paperspace-go => github.com/Paperspace/paperspace-go v0.3.0
 
-replace k8s.io/kubernetes => /tmp/ca-update-vendor.Mabc/kubernetes
+replace k8s.io/kubernetes => /tmp/ca-update-vendor.HcNT/kubernetes

--- a/cluster-autoscaler/go.mod-extra
+++ b/cluster-autoscaler/go.mod-extra
@@ -4,7 +4,7 @@ go 1.12
 require (
   github.com/rancher/go-rancher v0.1.0
   github.com/aws/aws-sdk-go v1.28.14
-  github.com/paperspace/paperspace-go v0.2.0
+  github.com/Paperspace/paperspace-go v0.3.0
 )
 
 replace (

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -20,6 +20,8 @@ github.com/Microsoft/hcsshim v0.0.0-20190417211021-672e52e9209d h1:u64+IetywsPQ0
 github.com/Microsoft/hcsshim v0.0.0-20190417211021-672e52e9209d/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46 h1:lsxEuwrXEAokXB9qhlbKWPpo3KMLZQ5WB5WLQRW1uq0=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
+github.com/Paperspace/paperspace-go v0.3.0 h1:3WZjceCnwcRvh64vqWBnB5yOMJYxH5uC+2AL2e3iO8M=
+github.com/Paperspace/paperspace-go v0.3.0/go.mod h1:dtV/8NzfKc0mPp8zw6Gu2mUvWL5wvOYp/BV+0oaqoc0=
 github.com/PuerkitoBio/purell v1.1.0 h1:rmGxhojJlM0tuKtfdvliR84CFHljx9ag64t2xmVkjK4=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
@@ -276,8 +278,6 @@ github.com/opencontainers/runtime-spec v1.0.0 h1:O6L965K88AilqnxeYPks/75HLpp4IG+
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v0.0.0-20170621221121-4a2974bf1ee9 h1:vVmQZ2IaaEe1MiuvZQbcydTbnlTG0OnZO5/4j7VZv0A=
 github.com/opencontainers/selinux v0.0.0-20170621221121-4a2974bf1ee9/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
-github.com/paperspace/paperspace-go v0.2.0 h1:zlKEvKHz60WoQj8vZ6V6osucEj0ewcjgmMjscWOdv5Y=
-github.com/paperspace/paperspace-go v0.2.0/go.mod h1:fh6bwO/SH3/9LwS75Bzc9pZDvEoiEMXl6pa15X6ZUsg=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/cluster-autoscaler/vendor/github.com/paperspace/paperspace-go/go.mod
+++ b/cluster-autoscaler/vendor/github.com/paperspace/paperspace-go/go.mod
@@ -1,3 +1,3 @@
-module github.com/paperspace/paperspace-go
+module github.com/Paperspace/paperspace-go
 
 go 1.12

--- a/cluster-autoscaler/vendor/modules.txt
+++ b/cluster-autoscaler/vendor/modules.txt
@@ -53,6 +53,8 @@ github.com/Microsoft/hcsshim/internal/longpath
 github.com/Microsoft/hcsshim/internal/safefile
 # github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46 => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 github.com/NYTimes/gziphandler
+# github.com/Paperspace/paperspace-go v0.3.0 => github.com/Paperspace/paperspace-go v0.3.0
+github.com/Paperspace/paperspace-go
 # github.com/PuerkitoBio/purell v1.1.0 => github.com/PuerkitoBio/purell v1.1.0
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
@@ -430,8 +432,6 @@ github.com/opencontainers/runtime-spec/specs-go
 # github.com/opencontainers/selinux v0.0.0-20170621221121-4a2974bf1ee9 => github.com/opencontainers/selinux v0.0.0-20170621221121-4a2974bf1ee9
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
-# github.com/paperspace/paperspace-go v0.2.0 => github.com/paperspace/paperspace-go v0.2.0
-github.com/paperspace/paperspace-go
 # github.com/pborman/uuid v1.2.0 => github.com/pborman/uuid v1.2.0
 github.com/pborman/uuid
 # github.com/peterbourgon/diskv v2.0.1+incompatible => github.com/peterbourgon/diskv v2.0.1+incompatible
@@ -643,7 +643,7 @@ gopkg.in/square/go-jose.v2/json
 gopkg.in/warnings.v0
 # gopkg.in/yaml.v2 v2.2.8 => gopkg.in/yaml.v2 v2.2.8
 gopkg.in/yaml.v2
-# k8s.io/api v0.0.0 => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/api
+# k8s.io/api v0.0.0 => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/api
 k8s.io/api/core/v1
 k8s.io/api/apps/v1
 k8s.io/api/policy/v1beta1
@@ -682,9 +682,9 @@ k8s.io/api/authorization/v1
 k8s.io/api/authorization/v1beta1
 k8s.io/api/admission/v1beta1
 k8s.io/api/imagepolicy/v1alpha1
-# k8s.io/apiextensions-apiserver v0.0.0 => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/apiextensions-apiserver
+# k8s.io/apiextensions-apiserver v0.0.0 => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/apiextensions-apiserver
 k8s.io/apiextensions-apiserver/pkg/features
-# k8s.io/apimachinery v0.0.0 => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/apimachinery
+# k8s.io/apimachinery v0.0.0 => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/apimachinery
 k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/util/sets
@@ -744,7 +744,7 @@ k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/pkg/util/duration
 k8s.io/apimachinery/pkg/apis/meta/v1beta1/validation
 k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme
-# k8s.io/apiserver v0.0.0 => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/apiserver
+# k8s.io/apiserver v0.0.0 => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/apiserver
 k8s.io/apiserver/pkg/util/feature
 k8s.io/apiserver/pkg/features
 k8s.io/apiserver/pkg/admission
@@ -826,7 +826,7 @@ k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal
 k8s.io/apiserver/pkg/storage/etcd3
 k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission
 k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1
-# k8s.io/cli-runtime v0.0.0 => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/cli-runtime
+# k8s.io/cli-runtime v0.0.0 => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/cli-runtime
 k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
@@ -839,7 +839,7 @@ k8s.io/cli-runtime/pkg/kustomize/k8sdeps/configmapandsecret
 k8s.io/cli-runtime/pkg/kustomize/k8sdeps/transformer/hash
 k8s.io/cli-runtime/pkg/kustomize/k8sdeps/transformer/patch
 k8s.io/cli-runtime/pkg/kustomize/k8sdeps/kv
-# k8s.io/client-go v0.0.0 => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/client-go
+# k8s.io/client-go v0.0.0 => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/client-go
 k8s.io/client-go/kubernetes
 k8s.io/client-go/rest
 k8s.io/client-go/tools/clientcmd
@@ -1050,24 +1050,24 @@ k8s.io/client-go/discovery/cached/disk
 k8s.io/client-go/restmapper
 k8s.io/client-go/util/jsonpath
 k8s.io/client-go/third_party/forked/golang/template
-# k8s.io/cloud-provider v0.0.0 => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/cloud-provider
+# k8s.io/cloud-provider v0.0.0 => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/cloud-provider
 k8s.io/cloud-provider/volume
 k8s.io/cloud-provider
 k8s.io/cloud-provider/node/helpers
 k8s.io/cloud-provider/service/helpers
 k8s.io/cloud-provider/volume/errors
 k8s.io/cloud-provider/volume/helpers
-# k8s.io/component-base v0.0.0 => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/component-base
+# k8s.io/component-base v0.0.0 => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/component-base
 k8s.io/component-base/cli/flag
 k8s.io/component-base/config
 k8s.io/component-base/featuregate
 k8s.io/component-base/logs
 k8s.io/component-base/config/v1alpha1
 k8s.io/component-base/metrics
-# k8s.io/cri-api v0.0.0 => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/cri-api
+# k8s.io/cri-api v0.0.0 => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/cri-api
 k8s.io/cri-api/pkg/apis
 k8s.io/cri-api/pkg/apis/runtime/v1alpha2
-# k8s.io/csi-translation-lib v0.0.0 => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/csi-translation-lib
+# k8s.io/csi-translation-lib v0.0.0 => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/csi-translation-lib
 k8s.io/csi-translation-lib/plugins
 k8s.io/csi-translation-lib
 # k8s.io/klog v0.3.1 => k8s.io/klog v0.3.1
@@ -1079,11 +1079,11 @@ k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/handler
 k8s.io/kube-openapi/pkg/util
 k8s.io/kube-openapi/pkg/schemaconv
-# k8s.io/kube-proxy v0.0.0 => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/kube-proxy
+# k8s.io/kube-proxy v0.0.0 => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/kube-proxy
 k8s.io/kube-proxy/config/v1alpha1
-# k8s.io/kubelet v0.0.0 => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/kubelet
+# k8s.io/kubelet v0.0.0 => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/kubelet
 k8s.io/kubelet/config/v1beta1
-# k8s.io/kubernetes v0.0.0 => /tmp/ca-update-vendor.Mabc/kubernetes
+# k8s.io/kubernetes v0.0.0 => /tmp/ca-update-vendor.HcNT/kubernetes
 k8s.io/kubernetes/pkg/client/leaderelectionconfig
 k8s.io/kubernetes/pkg/kubelet/types
 k8s.io/kubernetes/pkg/scheduler/nodeinfo
@@ -1462,7 +1462,7 @@ k8s.io/kubernetes/pkg/kubectl/util/qos
 k8s.io/kubernetes/pkg/kubectl/util/rbac
 k8s.io/kubernetes/pkg/kubectl/util/resource
 k8s.io/kubernetes/pkg/kubectl/util/storage
-# k8s.io/legacy-cloud-providers v0.0.0 => /tmp/ca-update-vendor.Mabc/kubernetes/staging/src/k8s.io/legacy-cloud-providers
+# k8s.io/legacy-cloud-providers v0.0.0 => /tmp/ca-update-vendor.HcNT/kubernetes/staging/src/k8s.io/legacy-cloud-providers
 k8s.io/legacy-cloud-providers/aws
 k8s.io/legacy-cloud-providers/gce
 k8s.io/legacy-cloud-providers/azure


### PR DESCRIPTION
Necessitated by https://github.com/Paperspace/paperspace-go/pull/11.